### PR TITLE
Use the vizkit_debug_drawings library that only has the commands

### DIFF
--- a/vizkit3d_debug_drawings.orogen
+++ b/vizkit3d_debug_drawings.orogen
@@ -1,6 +1,6 @@
 name "vizkit3d_debug_drawings"
 
-using_library 'vizkit3d_debug_drawings'
+using_library 'vizkit3d_debug_drawings-commands'
 
 #import opaque wrapper
 import_types_from "wrappers/CommandWrapper.hpp"


### PR DESCRIPTION
That library does not depend on qt and thus the transports and typekit generated here do not, either.

This is the other piece that requires and complements https://github.com/rock-gui/gui-vizkit3d_debug_drawings/pull/8
@planthaber 